### PR TITLE
fix: types export on react package

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -42,7 +42,8 @@
   "exports": {
     ".": {
       "import": "./dist/blossom-carousel-react.js",
-      "require": "./dist/blossom-carousel-react.umd.cjs"
+      "require": "./dist/blossom-carousel-react.umd.cjs",
+      "types": "./dist/index.d.ts"
     },
     "./style.css": "./dist/blossom-carousel-react.css"
   },


### PR DESCRIPTION
On react package, types export are broken:
<img width="1512" alt="Screenshot 2025-06-25 at 10 36 08" src="https://github.com/user-attachments/assets/61b7940a-f9b2-4905-bea9-4b7f6181ef68" />


Adding the "types": "./dist/index.d.ts" package.json fixes it.