### PR TITLE
Fix/react initialization

### DIFF
--- a/packages/react/src/BlossomCarousel.jsx
+++ b/packages/react/src/BlossomCarousel.jsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { Blossom } from "@blossom-carousel/core";
 import "@blossom-carousel/core/style.css";
 
@@ -10,7 +10,7 @@ const BlossomCarousel = ({
 }) => {
   const rootRef = useRef(null);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     // const blossom = Blossom(rootRef.current, { repeat });
     const blossom = Blossom(rootRef.current);
     blossom.init();


### PR DESCRIPTION
The useEffect hook is missing a dependency array, which will cause the effect to run on every rerender and not only once to initialize it.