### PR TITLE
fix: reset animation target on pointerdown to prevent jump when re-dragging mid-deceleration

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -268,12 +268,14 @@ export const Blossom = (scroller: HTMLElement, options: CarouselOptions) => {
 
     if (hasOverflow.x) {
       virtualScroll.x = scroller.scrollLeft;
+      target.x = scroller.scrollLeft;
       pointerStart.x = e.clientX;
       velocity.x = 0;
     }
 
     if (hasOverflow.y) {
       virtualScroll.y = scroller.scrollTop;
+      target.y = scroller.scrollTop;
       pointerStart.y = e.clientY;
       velocity.y = 0;
     }


### PR DESCRIPTION
Hey! Made this small tweak to the library for a client project to fix a jumpy animation when rapidly dragging the carousel with a mouse, think it's more noticeable on windows. When starting a new drag before a previous one has finished, the `target` values used for the animation weren't being reset so it was holding onto those stale values and causing a visible jump in some instances