### PR TITLE
feat: Add custom inner content for next/prev buttons for web components

### DIFF
--- a/packages/web/src/BlossomNext.ts
+++ b/packages/web/src/BlossomNext.ts
@@ -18,7 +18,12 @@ export class BlossomNext extends HTMLElementBase {
     this.button.setAttribute("commandfor", forId);
     this.button.setAttribute("aria-controls", forId);
     this.button.setAttribute("aria-label", "Next slide");
-    this.button.textContent = this.textContent?.trim() || "Next";
+
+    const content = this.childNodes.length > 0
+      ? Array.from(this.childNodes)
+      : [document.createTextNode("Next")];
+    
+    this.button.replaceChildren(...content);
     this.replaceChildren(this.button);
 
     this.cleanup = connectNavigation(forId, (state) => {

--- a/packages/web/src/BlossomPrev.ts
+++ b/packages/web/src/BlossomPrev.ts
@@ -18,7 +18,12 @@ export class BlossomPrev extends HTMLElementBase {
     this.button.setAttribute("commandfor", forId);
     this.button.setAttribute("aria-controls", forId);
     this.button.setAttribute("aria-label", "Previous slide");
-    this.button.textContent = this.textContent?.trim() || "Previous";
+    
+    const content = this.childNodes.length > 0
+      ? Array.from(this.childNodes)
+      : [document.createTextNode("Previous")];
+    
+    this.button.replaceChildren(...content);
     this.replaceChildren(this.button);
 
     this.cleanup = connectNavigation(forId, (state) => {


### PR DESCRIPTION
### Summary
This PR updates `<blossom-next>` and `<blossom-prev>` to support arbitrary HTML content (such as SVG icons) instead of being restricted to plain text via `textContent`

### Motivation
Currently, using custom icons like SVGs inside the navigation components gets overwritten at runtime:
```
<blossom-next for="carousel-0">
  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><path d="M566.6 342.6C579.1 330.1 579.1 309.8 566.6 297.3L406.6 137.3C394.1 124.8 373.8 124.8 361.3 137.3C348.8 149.8 348.8 170.1 361.3 182.6L466.7 288L96 288C78.3 288 64 302.3 64 320C64 337.7 78.3 352 96 352L466.7 352L361.3 457.4C348.8 469.9 348.8 490.2 361.3 502.7C373.8 515.2 394.1 515.2 406.6 502.7L566.6 342.7z"/></svg>
</blossom-next>
```

This change allows developers to use custom buttons and icons while safely falling back to "Next" / "Previous" if no children are provided.