### PR TITLE
Export `useNavigation` from the vue package and accept `MaybeRef<string>` as the id argument

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -5,4 +5,7 @@ import BlossomNext from "./BlossomNext.vue";
 import BlossomDots from "./BlossomDots.vue";
 import BlossomDot from "./BlossomDot.vue";
 
+export { useNavigation } from "./useNavigation";
+export type { NavigationState } from "./useNavigation";
+
 export { BlossomCarousel, BlossomPrev, BlossomNext, BlossomDots, BlossomDot };

--- a/packages/vue/src/useNavigation.ts
+++ b/packages/vue/src/useNavigation.ts
@@ -3,8 +3,10 @@ import {
   onMounted,
   onBeforeUnmount,
   ref,
+  toRef,
   watch,
   type App,
+  type MaybeRef,
   type Ref,
 } from "vue";
 import {
@@ -60,7 +62,10 @@ const INITIAL: NavigationState = {
  * navigation state. Never touches a Blossom instance, so it works even when
  * Blossom isn't initialized.
  */
-export function useNavigation(forId: Ref<string>): Ref<NavigationState> {
+export function useNavigation(
+  forId: MaybeRef<string | undefined>,
+): Ref<NavigationState> {
+  const forIdRef = toRef(forId);
   // Captured once, in setup scope: getCurrentInstance() returns null once we're
   // inside a watch callback or lifecycle-hook microtask, so it can't be read lazily.
   const app = getCurrentInstance()?.appContext.app;
@@ -70,7 +75,7 @@ export function useNavigation(forId: Ref<string>): Ref<NavigationState> {
     return { ...INITIAL, count };
   }
 
-  const state = ref<NavigationState>(seededState(forId.value));
+  const state = ref<NavigationState>(seededState(forIdRef.value));
   let cleanup: (() => void) | null = null;
   // Distinguishes "not yet mounted" from "attach() ran but found nothing", so a
   // pre-mount `forId` change doesn't get mistaken for a live attachment to retry.
@@ -101,7 +106,7 @@ export function useNavigation(forId: Ref<string>): Ref<NavigationState> {
   }
 
   watch(
-    forId,
+    forIdRef,
     (id) => {
       if (mounted) {
         attach(id);
@@ -114,7 +119,7 @@ export function useNavigation(forId: Ref<string>): Ref<NavigationState> {
 
   onMounted(() => {
     mounted = true;
-    attach(forId.value);
+    attach(forIdRef.value);
   });
   onBeforeUnmount(detach);
 


### PR DESCRIPTION
## Summary

Resolves #30

Export `useNavigation` from the vue library entry file and update it so it accepts `MaybeRef<string>` instead of `Ref<string>` for the id argument.

## Changes

- export `useNavigation` from `@blossom-carousel/vue`
- export the Vue package `NavigationState` type
- update `useNavigation` to accept `MaybeRef<string | undefined>` instead of only `Ref<string>`

## Why

Vue developers currently cannot import the package's internal navigation composable, even though it is already used by `BlossomPrev`, `BlossomNext`, and `BlossomDots`.

Exposing it makes it possible to build custom UI based on:
- `canPrev`
- `canNext`
- `activeIndex`
- `count`

Accepting `MaybeRef<string | undefined>` also makes the API more ergonomic by allowing plain ids such as the value returned by vue's `useId()` without wrapping them manually in `ref()`.