### PR TITLE
Fix vue types export paths

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -39,10 +39,10 @@
   ],
   "main": "dist/blossom-carousel-vue.umd.cjs",
   "module": "dist/blossom-carousel-vue.js",
-  "types": "./dist/src/index.d.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/blossom-carousel-vue.js",
       "require": "./dist/blossom-carousel-vue.umd.cjs"
     },


### PR DESCRIPTION
Fixes #33

Changed types export paths from `./dist/src/index.d.ts` to `./dist/index.d.ts` in the vue package to reflect the new bundle structure introduced by the `1.6.0` release.